### PR TITLE
Do not swallow errors when rendering illustrations

### DIFF
--- a/src/excalidraw-embed/get-image.js
+++ b/src/excalidraw-embed/get-image.js
@@ -12,16 +12,22 @@ module.exports = async (url) => {
   const frame = await page.mainFrame();
   const result = await frame.evaluate(
     () =>
-      new Promise((resolve) => {
-        const button = document.querySelector('[aria-label="Export to SVG"]');
-        const link = document.createElement("a");
-        delete window.chooseFileSystemEntries;
-        document.createElement = () => link;
-        link.click = () =>
-          fetch(link.href)
-            .then((res) => res.text())
-            .then(resolve);
-        button.click();
+      new Promise((resolve, error) => {
+        try {
+          const button = document.querySelector('[aria-label="Export to SVG"]');
+          const link = document.createElement("a");
+          delete window.chooseFileSystemEntries;
+          document.createElement = () => link;
+          link.click = () => {
+            fetch(link.href)
+              .then((res) => res.text())
+              .then(resolve)
+              .catch(error);
+          };
+          button.click();
+        } catch (e) {
+          error(e);
+        }
       })
   );
   await browser.close();


### PR DESCRIPTION
Otherwise it makes gatbsy hang forever with no explanations...

Now it fails to generate the two blog posts with error messages and no longer hangs

![image](https://user-images.githubusercontent.com/197597/79081966-0dd38400-7cd7-11ea-9803-f5fec6b7a74f.png)

![image](https://user-images.githubusercontent.com/197597/79081983-1fb52700-7cd7-11ea-8505-3d698ffdaea0.png)
