### PR TITLE
Smaller size for code/pre

### DIFF
--- a/src/code.css
+++ b/src/code.css
@@ -2,7 +2,6 @@ code[class*="language-"],
 pre[class*="language-"] {
   color: #657b83; /* base00 */
   font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-  font-size: 1em;
   text-align: left;
   white-space: pre;
   word-spacing: normal;


### PR DESCRIPTION
### [Before](https://blog.excalidraw.com/browser-nativefs/) vs [After](https://excalidraw-blog-git-decrease-code.excalidraw.vercel.app/browser-nativefs/)