### PR TITLE
minor fix: Dark Mode Toggle

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -28,6 +28,7 @@ const Layout = ({ location, title, children, parentClassName }) => {
       >
         <ThemeToggler>
           {({ theme, toggleTheme }) => {
+            if (theme == null) return null;
             return (
               <Toggle
                 icons={{


### PR DESCRIPTION
The toggle previously took a couple of clicks on production to reflect the correct state (Check the attached video recording).

https://github.com/excalidraw/excalidraw-blog/assets/35926159/ae68e23d-ce50-4a52-88b0-cecfc24de466

This was due to a bug in the underlying `gatsby-plugin-dark-mode` plugin.

This commit works around the issue using [this update](https://github.com/insin/gatsby-plugin-dark-mode/commit/83409b53ecdcc5809d75bb11548eec4bfb8acebc).

**Ref issues and code snippets:**
https://github.com/insin/gatsby-plugin-dark-mode/issues/13
https://github.com/TimTree/games-by-tim/issues/1